### PR TITLE
Add AlertBanner component with tests and stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
   },
   "dependencies": {
     "material-ui-vite-ts": "github:buildernick/mui-vite-demo"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/storybook/src/components/AlertBanner.tsx
+++ b/storybook/src/components/AlertBanner.tsx
@@ -1,0 +1,325 @@
+import * as React from "react";
+import { Box, IconButton, Button, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+
+export type AlertSeverity = "error" | "warning" | "info" | "success";
+export type AlertVariant = "filled" | "outlined" | "standard";
+
+export interface AlertBannerProps {
+  severity?: AlertSeverity;
+  variant?: AlertVariant;
+  title?: string;
+  description?: string;
+  showTitle?: boolean;
+  showDescription?: boolean;
+  onClose?: () => void;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  sx?: object;
+}
+
+const severityConfig = {
+  error: {
+    icon: ErrorOutlineIcon,
+    colors: {
+      filled: {
+        background: "#D32F2F",
+        color: "#FFFFFF",
+        iconColor: "#FFFFFF",
+      },
+      outlined: {
+        background: "#FFFFFF",
+        color: "#5F2120",
+        iconColor: "#D32F2F",
+        border: "1px solid #D32F2F",
+      },
+      standard: {
+        background: "#FDEDED",
+        color: "#5F2120",
+        iconColor: "#D32F2F",
+      },
+    },
+  },
+  warning: {
+    icon: WarningAmberOutlinedIcon,
+    colors: {
+      filled: {
+        background: "#EF6C00",
+        color: "#FFFFFF",
+        iconColor: "#FFFFFF",
+      },
+      outlined: {
+        background: "#FFFFFF",
+        color: "#663C00",
+        iconColor: "#EF6C00",
+        border: "1px solid #EF6C00",
+      },
+      standard: {
+        background: "#FFF4E5",
+        color: "#663C00",
+        iconColor: "#EF6C00",
+      },
+    },
+  },
+  info: {
+    icon: InfoOutlinedIcon,
+    colors: {
+      filled: {
+        background: "#0288D1",
+        color: "#FFFFFF",
+        iconColor: "#FFFFFF",
+      },
+      outlined: {
+        background: "#FFFFFF",
+        color: "#014361",
+        iconColor: "#0288D1",
+        border: "1px solid #0288D1",
+      },
+      standard: {
+        background: "#E5F6FD",
+        color: "#014361",
+        iconColor: "#0288D1",
+      },
+    },
+  },
+  success: {
+    icon: CheckCircleOutlinedIcon,
+    colors: {
+      filled: {
+        background: "#2E7D32",
+        color: "#FFFFFF",
+        iconColor: "#FFFFFF",
+      },
+      outlined: {
+        background: "#FFFFFF",
+        color: "#1E4620",
+        iconColor: "#2E7D32",
+        border: "1px solid #2E7D32",
+      },
+      standard: {
+        background: "#EDF7ED",
+        color: "#1E4620",
+        iconColor: "#2E7D32",
+      },
+    },
+  },
+};
+
+const AlertContainer = styled(Box)<{
+  alertSeverity: AlertSeverity;
+  alertVariant: AlertVariant;
+}>(({ alertSeverity, alertVariant }) => {
+  const config = severityConfig[alertSeverity].colors[alertVariant];
+
+  return {
+    display: "flex",
+    alignItems: "flex-start",
+    padding: "6px 16px",
+    borderRadius: "4px",
+    backgroundColor: config.background,
+    color: config.color,
+    border: config.border || "none",
+    fontFamily: "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+    width: "100%",
+    minHeight: "48px",
+
+    "@media (max-width: 600px)": {
+      padding: "8px 12px",
+      flexDirection: "column",
+      gap: "8px",
+    },
+  };
+});
+
+const IconContainer = styled(Box)({
+  display: "flex",
+  padding: "7px 12px 7px 0px",
+  alignItems: "flex-start",
+  flexShrink: 0,
+
+  "@media (max-width: 600px)": {
+    padding: "4px 8px 4px 0px",
+  },
+});
+
+const ContentContainer = styled(Box)({
+  display: "flex",
+  padding: "8px 0px",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "4px",
+  flex: "1 0 0",
+});
+
+const ActionsContainer = styled(Box)({
+  display: "flex",
+  padding: "4px 0px 0px 16px",
+  alignItems: "flex-start",
+  flexShrink: 0,
+
+  "@media (max-width: 600px)": {
+    padding: "4px 0px",
+    width: "100%",
+    justifyContent: "flex-end",
+  },
+});
+
+const AlertTitle = styled(Typography)<{
+  alertSeverity: AlertSeverity;
+  alertVariant: AlertVariant;
+}>(({ alertSeverity, alertVariant }) => {
+  const config = severityConfig[alertSeverity].colors[alertVariant];
+
+  return {
+    alignSelf: "stretch",
+    color: config.color,
+    fontFamily: "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+    fontSize: "16px",
+    fontStyle: "normal",
+    fontWeight: 500,
+    lineHeight: "150%",
+    letterSpacing: "0.15px",
+    margin: 0,
+  };
+});
+
+const AlertDescription = styled(Typography)<{
+  alertSeverity: AlertSeverity;
+  alertVariant: AlertVariant;
+}>(({ alertSeverity, alertVariant }) => {
+  const config = severityConfig[alertSeverity].colors[alertVariant];
+
+  return {
+    alignSelf: "stretch",
+    color: config.color,
+    fontFamily: "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+    fontSize: "14px",
+    fontStyle: "normal",
+    fontWeight: 400,
+    lineHeight: "143%",
+    letterSpacing: "0.17px",
+    margin: 0,
+  };
+});
+
+const StyledIconButton = styled(IconButton)<{
+  alertSeverity: AlertSeverity;
+  alertVariant: AlertVariant;
+}>(({ alertSeverity, alertVariant }) => {
+  const config = severityConfig[alertSeverity].colors[alertVariant];
+
+  return {
+    padding: "5px",
+    borderRadius: "100px",
+    color: config.color,
+    "&:hover": {
+      backgroundColor: "rgba(0, 0, 0, 0.04)",
+    },
+  };
+});
+
+const StyledActionButton = styled(Button)<{
+  alertSeverity: AlertSeverity;
+  alertVariant: AlertVariant;
+}>(({ alertSeverity, alertVariant }) => {
+  const config = severityConfig[alertSeverity].colors[alertVariant];
+
+  return {
+    padding: "4px 5px",
+    borderRadius: "4px",
+    color: config.color,
+    fontSize: "13px",
+    fontWeight: 500,
+    lineHeight: "22px",
+    letterSpacing: "0.46px",
+    textTransform: "uppercase",
+    "&:hover": {
+      backgroundColor: "rgba(0, 0, 0, 0.04)",
+    },
+  };
+});
+
+export default function AlertBanner({
+  severity = "info",
+  variant = "standard",
+  title,
+  description,
+  showTitle = true,
+  showDescription = true,
+  onClose,
+  action,
+  sx,
+}: AlertBannerProps) {
+  const IconComponent = severityConfig[severity].icon;
+  const config = severityConfig[severity].colors[variant];
+
+  return (
+    <AlertContainer alertSeverity={severity} alertVariant={variant} sx={sx}>
+      <IconContainer>
+        <IconComponent
+          sx={{
+            width: "22px",
+            height: "22px",
+            color: config.iconColor,
+          }}
+        />
+      </IconContainer>
+
+      <ContentContainer>
+        {showTitle && title && (
+          <AlertTitle
+            alertSeverity={severity}
+            alertVariant={variant}
+            component="div"
+          >
+            {title}
+          </AlertTitle>
+        )}
+
+        {showDescription && description && (
+          <AlertDescription
+            alertSeverity={severity}
+            alertVariant={variant}
+            component="div"
+          >
+            {description}
+          </AlertDescription>
+        )}
+      </ContentContainer>
+
+      {(onClose || action) && (
+        <ActionsContainer>
+          {action && (
+            <StyledActionButton
+              alertSeverity={severity}
+              alertVariant={variant}
+              variant="text"
+              size="small"
+              onClick={action.onClick}
+            >
+              {action.label}
+            </StyledActionButton>
+          )}
+
+          {onClose && (
+            <StyledIconButton
+              alertSeverity={severity}
+              alertVariant={variant}
+              size="small"
+              onClick={onClose}
+            >
+              <CloseIcon sx={{ width: "20px", height: "20px" }} />
+            </StyledIconButton>
+          )}
+        </ActionsContainer>
+      )}
+    </AlertContainer>
+  );
+}

--- a/storybook/src/components/AlertBanner.tsx
+++ b/storybook/src/components/AlertBanner.tsx
@@ -5,9 +5,15 @@ import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import CircleOutlinedIcon from "@mui/icons-material/CircleOutlined";
 import CloseIcon from "@mui/icons-material/Close";
 
-export type AlertSeverity = "error" | "warning" | "info" | "success";
+export type AlertSeverity =
+  | "error"
+  | "warning"
+  | "info"
+  | "success"
+  | "nothing";
 export type AlertVariant = "filled" | "outlined" | "standard";
 
 export interface AlertBannerProps {
@@ -107,6 +113,27 @@ const severityConfig = {
         background: "#EDF7ED",
         color: "#1E4620",
         iconColor: "#2E7D32",
+      },
+    },
+  },
+  nothing: {
+    icon: CircleOutlinedIcon,
+    colors: {
+      filled: {
+        background: "#FFFFFF",
+        color: "#000000",
+        iconColor: "#000000",
+      },
+      outlined: {
+        background: "#FFFFFF",
+        color: "#000000",
+        iconColor: "#000000",
+        border: "1px solid #E0E0E0",
+      },
+      standard: {
+        background: "#FFFFFF",
+        color: "#000000",
+        iconColor: "#000000",
       },
     },
   },

--- a/storybook/src/components/__tests__/AlertBanner.test.tsx
+++ b/storybook/src/components/__tests__/AlertBanner.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AlertBanner from "../AlertBanner";
+
+describe("AlertBanner", () => {
+  it("renders with default props", () => {
+    render(<AlertBanner />);
+    expect(screen.getByRole("img", { hidden: true })).toBeInTheDocument(); // Icon
+  });
+
+  it("renders title and description when provided", () => {
+    render(<AlertBanner title="Test Title" description="Test Description" />);
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Test Description")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const handleClose = jest.fn();
+    render(<AlertBanner title="Test Alert" onClose={handleClose} />);
+
+    const closeButton = screen.getByRole("button");
+    fireEvent.click(closeButton);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls action.onClick when action button is clicked", () => {
+    const handleAction = jest.fn();
+    render(
+      <AlertBanner
+        title="Test Alert"
+        action={{
+          label: "Test Action",
+          onClick: handleAction,
+        }}
+      />
+    );
+
+    const actionButton = screen.getByText("Test Action");
+    fireEvent.click(actionButton);
+
+    expect(handleAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders different severity levels correctly", () => {
+    const { rerender } = render(<AlertBanner severity="error" title="Error" />);
+    expect(screen.getByText("Error")).toBeInTheDocument();
+
+    rerender(<AlertBanner severity="warning" title="Warning" />);
+    expect(screen.getByText("Warning")).toBeInTheDocument();
+
+    rerender(<AlertBanner severity="info" title="Info" />);
+    expect(screen.getByText("Info")).toBeInTheDocument();
+
+    rerender(<AlertBanner severity="success" title="Success" />);
+    expect(screen.getByText("Success")).toBeInTheDocument();
+  });
+
+  it("hides title when showTitle is false", () => {
+    render(
+      <AlertBanner
+        title="Hidden Title"
+        description="Visible Description"
+        showTitle={false}
+      />
+    );
+
+    expect(screen.queryByText("Hidden Title")).not.toBeInTheDocument();
+    expect(screen.getByText("Visible Description")).toBeInTheDocument();
+  });
+
+  it("hides description when showDescription is false", () => {
+    render(
+      <AlertBanner
+        title="Visible Title"
+        description="Hidden Description"
+        showDescription={false}
+      />
+    );
+
+    expect(screen.getByText("Visible Title")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden Description")).not.toBeInTheDocument();
+  });
+});

--- a/storybook/stories/AlertBanner.stories.tsx
+++ b/storybook/stories/AlertBanner.stories.tsx
@@ -1,0 +1,513 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Box, Stack, Typography } from "@mui/material";
+import AlertBanner, {
+  AlertBannerProps,
+  AlertSeverity,
+  AlertVariant,
+} from "../src/components/AlertBanner";
+
+const meta: Meta<typeof AlertBanner> = {
+  title: "Components/AlertBanner",
+  component: AlertBanner,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "AlertBanner component for displaying important messages with different severity levels and variants. Supports filled, outlined, and standard variants with error, warning, info, and success severity levels.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    severity: {
+      control: { type: "select" },
+      options: ["error", "warning", "info", "success"],
+      description: "The severity level of the alert",
+    },
+    variant: {
+      control: { type: "select" },
+      options: ["filled", "outlined", "standard"],
+      description: "The visual variant of the alert",
+    },
+    title: {
+      control: { type: "text" },
+      description: "The title text of the alert",
+    },
+    description: {
+      control: { type: "text" },
+      description: "The description text of the alert",
+    },
+    showTitle: {
+      control: { type: "boolean" },
+      description: "Whether to show the title",
+    },
+    showDescription: {
+      control: { type: "boolean" },
+      description: "Whether to show the description",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Default story
+export const Default: Story = {
+  args: {
+    severity: "info",
+    variant: "standard",
+    title: "Information",
+    description: "This is an informational alert message.",
+    showTitle: true,
+    showDescription: true,
+  },
+};
+
+// Interactive playground
+export const Playground: Story = {
+  args: {
+    severity: "warning",
+    variant: "standard",
+    title: "Warning Alert",
+    description: "This is a warning message that you should pay attention to.",
+    showTitle: true,
+    showDescription: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interactive playground to test different combinations of props.",
+      },
+    },
+  },
+};
+
+// All Severity Levels - Standard Variant
+export const AllSeverityLevelsStandard: Story = {
+  render: () => {
+    const severities: AlertSeverity[] = ["success", "info", "warning", "error"];
+
+    return (
+      <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+        <Typography variant="h6" component="h2">
+          Standard Variant - All Severity Levels
+        </Typography>
+        {severities.map((severity) => (
+          <AlertBanner
+            key={severity}
+            severity={severity}
+            variant="standard"
+            title={`${
+              severity.charAt(0).toUpperCase() + severity.slice(1)
+            } Alert`}
+            description={`This is a ${severity} alert with standard variant styling.`}
+          />
+        ))}
+      </Stack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All severity levels (success, info, warning, error) using the standard variant.",
+      },
+    },
+  },
+};
+
+// All Severity Levels - Outlined Variant
+export const AllSeverityLevelsOutlined: Story = {
+  render: () => {
+    const severities: AlertSeverity[] = ["success", "info", "warning", "error"];
+
+    return (
+      <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+        <Typography variant="h6" component="h2">
+          Outlined Variant - All Severity Levels
+        </Typography>
+        {severities.map((severity) => (
+          <AlertBanner
+            key={severity}
+            severity={severity}
+            variant="outlined"
+            title={`${
+              severity.charAt(0).toUpperCase() + severity.slice(1)
+            } Alert`}
+            description={`This is a ${severity} alert with outlined variant styling.`}
+          />
+        ))}
+      </Stack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "All severity levels using the outlined variant with borders.",
+      },
+    },
+  },
+};
+
+// All Severity Levels - Filled Variant
+export const AllSeverityLevelsFilled: Story = {
+  render: () => {
+    const severities: AlertSeverity[] = ["success", "info", "warning", "error"];
+
+    return (
+      <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+        <Typography variant="h6" component="h2">
+          Filled Variant - All Severity Levels
+        </Typography>
+        {severities.map((severity) => (
+          <AlertBanner
+            key={severity}
+            severity={severity}
+            variant="filled"
+            title={`${
+              severity.charAt(0).toUpperCase() + severity.slice(1)
+            } Alert`}
+            description={`This is a ${severity} alert with filled variant styling.`}
+          />
+        ))}
+      </Stack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All severity levels using the filled variant with solid backgrounds.",
+      },
+    },
+  },
+};
+
+// Complete Variant Matrix
+export const CompleteVariantMatrix: Story = {
+  render: () => {
+    const severities: AlertSeverity[] = ["error", "warning", "info", "success"];
+    const variants: AlertVariant[] = ["filled", "outlined", "standard"];
+
+    return (
+      <Stack spacing={4} sx={{ width: "100%", maxWidth: 800 }}>
+        <Typography variant="h5" component="h2">
+          Complete Alert Variant Matrix
+        </Typography>
+        {variants.map((variant) => (
+          <Box key={variant}>
+            <Typography
+              variant="h6"
+              component="h3"
+              sx={{ mb: 2, textTransform: "capitalize" }}
+            >
+              {variant} Variant
+            </Typography>
+            <Stack spacing={2}>
+              {severities.map((severity) => (
+                <AlertBanner
+                  key={`${variant}-${severity}`}
+                  severity={severity}
+                  variant={variant}
+                  title={`${
+                    severity.charAt(0).toUpperCase() + severity.slice(1)
+                  }`}
+                  description={`${
+                    severity.charAt(0).toUpperCase() + severity.slice(1)
+                  } description`}
+                />
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Complete matrix showing all combinations of severity levels and variants.",
+      },
+    },
+  },
+};
+
+// With Close Button
+export const WithCloseButton: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+      <Typography variant="h6" component="h2">
+        Alerts with Close Button
+      </Typography>
+      <AlertBanner
+        severity="warning"
+        variant="standard"
+        title="Dismissible Warning"
+        description="This alert displays the default close icon."
+        onClose={() => alert("Alert closed!")}
+      />
+      <AlertBanner
+        severity="error"
+        variant="outlined"
+        title="Critical Error"
+        description="This error alert can be dismissed by clicking the close button."
+        onClose={() => alert("Error alert closed!")}
+      />
+      <AlertBanner
+        severity="success"
+        variant="filled"
+        title="Success"
+        description="Operation completed successfully. Click to dismiss."
+        onClose={() => alert("Success alert closed!")}
+      />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Alerts with close buttons that can be dismissed by users.",
+      },
+    },
+  },
+};
+
+// With Action Button
+export const WithActionButton: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+      <Typography variant="h6" component="h2">
+        Alerts with Action Button
+      </Typography>
+      <AlertBanner
+        severity="success"
+        variant="standard"
+        title="Operation Complete"
+        description="This Alert uses a Button component for its action."
+        action={{
+          label: "UNDO",
+          onClick: () => alert("Undo action clicked!"),
+        }}
+      />
+      <AlertBanner
+        severity="info"
+        variant="outlined"
+        title="Update Available"
+        description="A new version of the application is available."
+        action={{
+          label: "UPDATE",
+          onClick: () => alert("Update action clicked!"),
+        }}
+      />
+      <AlertBanner
+        severity="warning"
+        variant="filled"
+        title="Storage Almost Full"
+        description="Your storage is 90% full. Consider freeing up some space."
+        action={{
+          label: "MANAGE",
+          onClick: () => alert("Manage storage clicked!"),
+        }}
+      />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Alerts with action buttons for user interactions.",
+      },
+    },
+  },
+};
+
+// With Both Close and Action
+export const WithBothCloseAndAction: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+      <Typography variant="h6" component="h2">
+        Alerts with Both Close and Action Buttons
+      </Typography>
+      <AlertBanner
+        severity="warning"
+        variant="standard"
+        title="Connection Issue"
+        description="Unable to connect to the server. Check your internet connection."
+        action={{
+          label: "RETRY",
+          onClick: () => alert("Retry clicked!"),
+        }}
+        onClose={() => alert("Alert dismissed!")}
+      />
+      <AlertBanner
+        severity="error"
+        variant="outlined"
+        title="Payment Failed"
+        description="Your payment could not be processed. Please try again."
+        action={{
+          label: "RETRY PAYMENT",
+          onClick: () => alert("Retry payment clicked!"),
+        }}
+        onClose={() => alert("Payment alert dismissed!")}
+      />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Alerts with both action and close buttons for maximum flexibility.",
+      },
+    },
+  },
+};
+
+// Title Only
+export const TitleOnly: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+      <Typography variant="h6" component="h2">
+        Title Only Alerts
+      </Typography>
+      <AlertBanner
+        severity="error"
+        variant="filled"
+        title="Critical Error Occurred"
+        showDescription={false}
+      />
+      <AlertBanner
+        severity="warning"
+        variant="outlined"
+        title="Warning Message"
+        showDescription={false}
+      />
+      <AlertBanner
+        severity="success"
+        variant="standard"
+        title="Success"
+        showDescription={false}
+      />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Alerts showing only the title without description text.",
+      },
+    },
+  },
+};
+
+// Description Only
+export const DescriptionOnly: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
+      <Typography variant="h6" component="h2">
+        Description Only Alerts
+      </Typography>
+      <AlertBanner
+        severity="info"
+        variant="standard"
+        description="This is a success Alert with warning colors."
+        showTitle={false}
+      />
+      <AlertBanner
+        severity="warning"
+        variant="outlined"
+        description="Important information that doesn't need a title."
+        showTitle={false}
+      />
+      <AlertBanner
+        severity="success"
+        variant="filled"
+        description="Operation completed successfully without any issues."
+        showTitle={false}
+      />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Alerts showing only the description without title text.",
+      },
+    },
+  },
+};
+
+// Long Content
+export const LongContent: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ width: "100%", maxWidth: 800 }}>
+      <Typography variant="h6" component="h2">
+        Alerts with Long Content
+      </Typography>
+      <AlertBanner
+        severity="error"
+        variant="standard"
+        title="Authentication Error - Unable to Process Request"
+        description="Your session has expired due to inactivity. This is a security measure to protect your account. Please log in again to continue using the application. If you continue to experience issues, please contact our support team for assistance."
+        onClose={() => alert("Long error alert closed!")}
+      />
+      <AlertBanner
+        severity="info"
+        variant="outlined"
+        title="System Maintenance Scheduled"
+        description="We will be performing scheduled maintenance on our servers this weekend from Saturday 2:00 AM to Sunday 6:00 AM EST. During this time, some features may be temporarily unavailable. We apologize for any inconvenience this may cause."
+        action={{
+          label: "LEARN MORE",
+          onClick: () => alert("Learn more clicked!"),
+        }}
+      />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Alerts with longer content to test text wrapping and layout.",
+      },
+    },
+  },
+};
+
+// Responsive Design
+export const ResponsiveDesign: Story = {
+  render: () => (
+    <Stack spacing={3}>
+      <Typography variant="h6" component="h2">
+        Responsive Design - Try resizing the viewport
+      </Typography>
+      <Box sx={{ width: "100%", maxWidth: 1200 }}>
+        <AlertBanner
+          severity="warning"
+          variant="standard"
+          title="Responsive Alert"
+          description="This alert adapts to different screen sizes. On mobile devices, the layout changes to stack elements vertically for better readability."
+          action={{
+            label: "ACTION",
+            onClick: () => alert("Responsive action clicked!"),
+          }}
+          onClose={() => alert("Responsive alert closed!")}
+        />
+      </Box>
+      <Box sx={{ width: "100%", maxWidth: 400 }}>
+        <AlertBanner
+          severity="info"
+          variant="outlined"
+          title="Mobile View"
+          description="This shows how the alert looks in a narrower container, similar to mobile viewport."
+          onClose={() => alert("Mobile alert closed!")}
+        />
+      </Box>
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates how alerts adapt to different screen sizes and container widths.",
+      },
+    },
+  },
+};

--- a/storybook/stories/AlertBanner.stories.tsx
+++ b/storybook/stories/AlertBanner.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof AlertBanner> = {
   argTypes: {
     severity: {
       control: { type: "select" },
-      options: ["error", "warning", "info", "success"],
+      options: ["error", "warning", "info", "success", "nothing"],
       description: "The severity level of the alert",
     },
     variant: {
@@ -88,7 +88,13 @@ export const Playground: Story = {
 // All Severity Levels - Standard Variant
 export const AllSeverityLevelsStandard: Story = {
   render: () => {
-    const severities: AlertSeverity[] = ["success", "info", "warning", "error"];
+    const severities: AlertSeverity[] = [
+      "success",
+      "info",
+      "warning",
+      "error",
+      "nothing",
+    ];
 
     return (
       <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
@@ -122,7 +128,13 @@ export const AllSeverityLevelsStandard: Story = {
 // All Severity Levels - Outlined Variant
 export const AllSeverityLevelsOutlined: Story = {
   render: () => {
-    const severities: AlertSeverity[] = ["success", "info", "warning", "error"];
+    const severities: AlertSeverity[] = [
+      "success",
+      "info",
+      "warning",
+      "error",
+      "nothing",
+    ];
 
     return (
       <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
@@ -155,7 +167,13 @@ export const AllSeverityLevelsOutlined: Story = {
 // All Severity Levels - Filled Variant
 export const AllSeverityLevelsFilled: Story = {
   render: () => {
-    const severities: AlertSeverity[] = ["success", "info", "warning", "error"];
+    const severities: AlertSeverity[] = [
+      "success",
+      "info",
+      "warning",
+      "error",
+      "nothing",
+    ];
 
     return (
       <Stack spacing={3} sx={{ width: "100%", maxWidth: 600 }}>
@@ -189,7 +207,13 @@ export const AllSeverityLevelsFilled: Story = {
 // Complete Variant Matrix
 export const CompleteVariantMatrix: Story = {
   render: () => {
-    const severities: AlertSeverity[] = ["error", "warning", "info", "success"];
+    const severities: AlertSeverity[] = [
+      "error",
+      "warning",
+      "info",
+      "success",
+      "nothing",
+    ];
     const variants: AlertVariant[] = ["filled", "outlined", "standard"];
 
     return (


### PR DESCRIPTION
This pull request adds a new AlertBanner component to the storybook with comprehensive testing and documentation.

Changes include:
- Add AlertBanner.tsx component with support for multiple severity levels (error, warning, info, success) and variants (filled, outlined, standard)
- Add comprehensive test suite in AlertBanner.test.tsx covering component rendering, user interactions, and prop handling
- Add detailed Storybook stories demonstrating all component variations and use cases
- Add packageManager field to package.json specifying yarn@1.22.22

The AlertBanner component features:
- Configurable severity and variant styling
- Optional title and description text
- Close button functionality
- Custom action button support
- Responsive design for mobile devices
- Material-UI integration with custom styled components

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/188708300bd54653981004fb9608349d/flare-garden)

👀 [Preview Link](https://188708300bd54653981004fb9608349d-flare-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>188708300bd54653981004fb9608349d</projectId>-->
<!--<branchName>flare-garden</branchName>-->